### PR TITLE
Introduce Utility.Result package and add result methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,36 @@ You can use the NUGET package named **Utility.Result** that is on nuget.org or a
 ### Returning a successful result from a function.
 
 ```
-Result Method()
-{
-    return Result.Ok();
-}
+    public Result ReturnOkResult()
+    {
+        return OkResult.Ok();
+    }
 ```
 
 ### Returning a successful result and value from a function.
 
 ```
-Result<int> Method()
-{
-    return Result.Ok(100);
-}
+    public ObjectResult<int> ReturnIntegerResult()
+    {
+        ObjectResult<int> result = OkObjectResult<int>.Ok(100);
+        return result;
+    }
 ```
 
 ### Returns a successful result from a task.
 
 ```
-Task Method()
-{
-  return Task.FromResult(Result.Ok());
-}
+    public Task<Result> ReturnResultForTask()
+    {
+        return Task.FromResult<Result>(OkResult.Ok());
+    }
 ```
 
 ### Returns a failure from a function
 
 ```
-Result Method()
-{
-    return Result.Fail("This function has failed because of...");
-}
+    public Result ReturnFailure()
+    {
+        return ErrorResult.Fail("This function has failed because of...");
+    }
 ```

--- a/Utility.Result.Tests/ObjectResultTests.cs
+++ b/Utility.Result.Tests/ObjectResultTests.cs
@@ -14,4 +14,25 @@ public class ObjectResultTests
         result.Error.MustBeNullOrEmpty();
         result.ErrorCode.MustBeZero();
     }
+
+    public Result ReturnOkResult()
+    {
+        return OkResult.Ok();
+    }
+
+    public ObjectResult<int> ReturnIntegerResult()
+    {
+        ObjectResult<int> result = OkObjectResult<int>.Ok(100);
+        return result;
+    }
+
+    public Task<Result> ReturnResultForTask()
+    {
+        return Task.FromResult<Result>(OkResult.Ok());
+    }
+
+    public Result ReturnFailure()
+    {
+        return ErrorResult.Fail("This function has failed because of...");
+    }
 }

--- a/Utility.Result.sln
+++ b/Utility.Result.sln
@@ -6,9 +6,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Utility.Result", "Utility.R
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Utility.Result.Tests", "Utility.Result.Tests\Utility.Result.Tests.csproj", "{2624FC37-2216-42F7-9640-D5751367986D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7E44851C-52C5-4453-A7FC-715B16AC294D}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {7D25D4C6-E7A0-4490-8BDE-9076CA666008}
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1A0DD539-9D41-4015-B493-48EFFAFDECE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -20,11 +26,10 @@ Global
 		{2624FC37-2216-42F7-9640-D5751367986D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2624FC37-2216-42F7-9640-D5751367986D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7D25D4C6-E7A0-4490-8BDE-9076CA666008}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
The changes introduce the usage of the Utility.Result NuGet package in the project, as described in the README.md file. Several methods have been added to the ObjectResultTests class in the ObjectResultTests.cs file to demonstrate how to return different types of results using the Utility.Result package:
- ReturnOkResult returns a successful result.
- ReturnIntegerResult returns a successful result with an integer value.
- ReturnResultForTask returns a successful result from a task.
- ReturnFailure returns a failure result.

The Utility.Result.sln solution file has been updated to include a new "Solution Items" project that contains the README.md file. Additionally, the solution configuration platforms section has been moved within the Global section, and the SolutionGuid has been re-added to the ExtensibilityGlobals section.